### PR TITLE
Fix parsing of spaces in LL(k) token definitions

### DIFF
--- a/src/Llk.php
+++ b/src/Llk.php
@@ -308,7 +308,7 @@ abstract class Llk
                                 $matches[3] .
                             ')';
                     }
-                } elseif (0 !== preg_match('#^%token\h+(?:([^:]+):)?([^\h]+)\h+(.*?)(?:\h+->\h+(.*))?$#u', $line, $matches)) {
+                } elseif (0 !== preg_match('#^%token\h+(?:([^:\s]+):)?([^\s]+)\h+(.*?)(?:\h+->\h+(.*))?$#u', $line, $matches)) {
                     if (empty($matches[1])) {
                         $matches[1] = 'default';
                     }


### PR DESCRIPTION
As mentioned [here](https://github.com/hoaproject/Compiler/pull/109#issuecomment-622398097), I'm working on a fork of the [Hoa\Regex](https://github.com/hoaproject/Regex) library, and got blocked when trying to implement support for POSIX classes.

Specifically, this definition:
```
%token negative_posix_class_ \[\:\^ -> pcc
```
currently defines a `\^` token in the `negative_posix_class_     \[\` namespace, and matching the `-> pcc` expression.

The fix prevents any kind of space from being considered as valid characters in either the token namespaces or codes, which seems to make most sense given the rest of the regex.